### PR TITLE
Fully worked out usher conversion

### DIFF
--- a/src/mat2tsk.py
+++ b/src/mat2tsk.py
@@ -11,7 +11,7 @@ import dataclasses
 import numpy as np
 import tskit
 import tqdm
-
+import click
 
 def set_tree_time(tables, unit_scale=False):
     # Add times using max number of hops from leaves.
@@ -134,7 +134,16 @@ def main(in_path, out_path):
     ts.dump(out_path)
 
 
-if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        raise ValueError("Usage: [usher in] [tskit out]")
-    main(sys.argv[1], sys.argv[2])
+@click.command()
+@click.argument("usher_json", type=click.Path(dir_okay=False, file_okay=True))
+@click.argument("tsk", type=click.Path(dir_okay=False, file_okay=True))
+def convert_topology(usher_json, tsk):
+    print("hello")
+
+@click.group()
+def cli():
+    pass
+
+cli.add_command(convert_topology)
+# cli.add_command(convert_mutations)
+cli()

--- a/src/mat2tsk.py
+++ b/src/mat2tsk.py
@@ -2,6 +2,9 @@
 Convert an Usher tree in JSON format to sc2ts-like tskit.
 
 https://figshare.com/articles/dataset/Global_Viridian_tree/27194547
+
+Also requires the mutations to be converted into nucleotide format using
+matutils.
 """
 
 import sys
@@ -12,9 +15,12 @@ import dataclasses
 import pandas as pd
 import numpy as np
 import tskit
+import tszip
 import tqdm
 import click
 import pyfaidx
+import numpy.testing as nt
+import numpy as np
 
 
 def set_mutations(ts, ref, mutations_per_node):
@@ -152,6 +158,120 @@ def convert_topology(usher_json, tsk):
     ts.dump(tsk)
 
 
+@click.command()
+@click.argument("usher_in", type=click.Path(dir_okay=False, file_okay=True))
+@click.argument("sc2ts_in", type=click.Path(dir_okay=False, file_okay=True))
+@click.argument("usher_out", type=click.Path(dir_okay=False, file_okay=True))
+@click.argument("sc2ts_out", type=click.Path(dir_okay=False, file_okay=True))
+@click.option(
+    "--intersect-sites/--no-intersect-sites",
+    default=True,
+    help="Reduce sites to the intersection of both (assuming sc2ts is superset)",
+    show_default=True,
+)
+def intersect(usher_in, sc2ts_in, usher_out, sc2ts_out, intersect_sites):
+    """
+    Compute the intersection of the samples and sites in the specified usher
+    and sc2ts ARGs. The output user and sc2ts files will contain the same
+    set of samples in the same order.
+    """
+    ts_usher_in = tszip.load(usher_in)
+    ts_sc2ts_in = tszip.load(sc2ts_in)
+
+    samples_strain_usher = ts_usher_in.metadata["sc2ts"]["samples_strain"]
+    samples_strain_sc2ts = ts_sc2ts_in.metadata["sc2ts"]["samples_strain"]
+    usher_lookup = dict(zip(samples_strain_usher, ts_usher_in.samples()))
+    sc2ts_lookup = dict(zip(samples_strain_sc2ts, ts_sc2ts_in.samples()))
+
+    intersection = set(usher_lookup.keys()) & set(sc2ts_lookup.keys())
+    print(
+        f"Usher: {len(usher_lookup)}; sc2ts: {len(sc2ts_lookup)} "
+        f"inter = {len(intersection)}"
+    )
+    intersection = sorted(intersection)
+
+    sc2ts_samples = [sc2ts_lookup[k] for k in intersection]
+    tables = ts_sc2ts_in.dump_tables()
+    tables.simplify(sc2ts_samples, filter_sites=False)
+    tables.metadata = {"sc2ts": {"samples_strain": intersection}}
+    ts_sc2ts_out = tables.tree_sequence()
+    del tables
+
+    usher_samples = [usher_lookup[k] for k in intersection]
+    tables = ts_usher_in.dump_tables()
+    tables.simplify(usher_samples, filter_sites=False)
+    tables.metadata = {"sc2ts": {"samples_strain": intersection}}
+    ts_usher_out = tables.tree_sequence()
+    del tables
+
+    if intersect_sites:
+        assert set(ts_sc2ts_out.sites_position) >= set(ts_usher_out.sites_position)
+        missing_positions = set(ts_sc2ts_out.sites_position) - set(
+            ts_usher_out.sites_position
+        )
+        missing_sites = np.searchsorted(
+            ts_sc2ts_out.sites_position, list(missing_positions)
+        )
+        ts_sc2ts_out = ts_sc2ts_out.delete_sites(missing_sites)
+
+    ts_sc2ts_out.dump(sc2ts_out)
+    ts_usher_out.dump(usher_out)
+
+
+@click.command()
+@click.argument("usher_path", type=click.Path(dir_okay=False, file_okay=True))
+@click.argument("sc2ts_path", type=click.Path(dir_okay=False, file_okay=True))
+def validate(usher_path, sc2ts_path):
+    """
+    Checks that the output of the intersect command above has the expected properties.
+    """
+    ts_usher = tszip.load(usher_path)
+    ts_sc2ts = tszip.load(sc2ts_path)
+    num_samples = ts_usher.num_samples
+    assert num_samples == ts_sc2ts.num_samples
+    num_sites = ts_usher.num_sites
+    assert num_sites == ts_sc2ts.num_sites
+    samples_strain = ts_sc2ts.metadata["sc2ts"]["samples_strain"]
+    assert samples_strain == ts_usher.metadata["sc2ts"]["samples_strain"]
+    nt.assert_array_equal(ts_usher.samples(), np.arange(num_samples))
+    nt.assert_array_equal(ts_sc2ts.samples(), np.arange(num_samples))
+
+    print(f"nodes: {ts_usher.num_nodes} {ts_sc2ts.num_nodes} "
+            f"{ts_sc2ts.num_nodes / ts_usher.num_nodes * 100 : .2f}%")
+    print(f"mutations: {ts_usher.num_mutations} {ts_sc2ts.num_mutations} "
+            f"{ts_sc2ts.num_mutations / ts_usher.num_mutations * 100 : .2f}%")
+
+    for u in tqdm.tqdm(range(num_samples), desc="Samples"):
+        sc2ts_node = ts_sc2ts.node(u)
+        usher_node = ts_usher.node(u)
+        assert sc2ts_node.metadata["strain"] == samples_strain[u]
+        assert usher_node.metadata["strain"] == samples_strain[u]
+
+    var_sc2ts = tskit.Variant(ts_sc2ts, alleles=tuple("ACGT"))
+    var_usher = tskit.Variant(ts_usher, alleles=tuple("ACGT"))
+
+    identical_sites = 0
+    total_diffs = 0
+    for j in tqdm.tqdm(range(num_sites), desc="Sites"):
+        var_sc2ts.decode(j)
+        var_usher.decode(j)
+        assert var_sc2ts.site.ancestral_state == var_usher.site.ancestral_state
+        assert var_sc2ts.alleles == var_usher.alleles
+        g_sc2ts = var_sc2ts.genotypes
+        g_usher = var_usher.genotypes
+        assert np.all(g_sc2ts >= 0)
+        assert np.all(g_usher >= 0)
+        diff = np.sum(g_sc2ts != g_usher)
+        if diff == 0:
+            identical_sites += 1
+        total_diffs += diff
+    print(f"identical_sites = {identical_sites} ({identical_sites / num_sites:.2f})")
+    print(f"total differences = {total_diffs}")
+    print(
+        f"fraction of genotypes different = {total_diffs / (num_sites * num_samples): .2g}"
+    )
+
+
 @click.group()
 def cli():
     """
@@ -162,4 +282,6 @@ def cli():
 
 cli.add_command(convert_topology)
 cli.add_command(convert_mutations)
+cli.add_command(intersect)
+cli.add_command(validate)
 cli()


### PR DESCRIPTION
Includes tool to make directly comparable sc2ts and usher tskit files (with the same set of samples in the same order, and the same sites) and to validate.

When we create the intersection files for the big usher tree and the current find-problematic-sites run, we get
```
$ python3 src/mat2tsk.py validate usher-2022-02-12.ts sc2ts-2022-02-12.ts
nodes: 423298 380085  89.79%
mutations: 536840 547300  101.95%
Samples: 100%|█████████████████████████████████████████████████████████████| 320728/320728 [00:24<00:00, 12842.21it/s]
Sites: 100%|███████████████████████████████████████████████████████████████████| 27508/27508 [00:55<00:00, 496.33it/s]
identical_sites = 25338 (0.92)
total differences = 136979
fraction of genotypes different =  1.6e-05
```

So, I think it's fairly clear that we're more-or-less representing the same data here (92% of sites having identical genotype patterns, and overall agreement of 99.999% on genotypes). I'm putting the mismatches down to different handling of deletions and the odd different imputation of Ns. I haven't checked this, though.

In terms of parsimony, I think we're doing pretty well. We have 2% more mutations, but this is on a rough first pass on less than 10% of the data. That seems pretty good to me.