### PR TITLE
Refactor novel recombinant analysis notebook

### DIFF
--- a/notebooks/nb_utils.py
+++ b/notebooks/nb_utils.py
@@ -921,6 +921,7 @@ def sample_subgraph(sample_node, ts, ti=None, **kwargs):
     return plot_subgraph(nodes, ts, ti, **kwargs)
 
 
+### Routines to facilitate analysis of novel recombinants.
 # Use pangonet to compute node distances between Pango labels.
 def initialise_pangonet(alias_key_file, lineage_notes_file):
     from pangonet.pangonet import PangoNet
@@ -940,3 +941,29 @@ def get_node_distance(pangonet, *, label_1, label_2):
     mrca_pango_2_distance = len(mrca_pango_2_path[0]) - 1
     node_distance = mrca_pango_1_distance + mrca_pango_2_distance
     return node_distance
+
+
+def plot_stacked_histogram(a, b, alegend, blegend, xlabel, ylabel, xlim):
+    bin_edges = np.arange(xlim[0], xlim[1])
+    hist_a, _ = np.histogram(a, bins=bin_edges)
+    hist_b, _ = np.histogram(b, bins=bin_edges)
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2 - 0.5
+    bar_width = 0.8
+    _, ax = plt.subplots()
+    _ = ax.bar(
+        bin_centers,
+        hist_a,
+        width=bar_width,
+        label=alegend,
+    )
+    _ = ax.bar(
+        bin_centers,
+        hist_b,
+        bottom=hist_a,
+        width=bar_width,
+        label=blegend,
+    )
+    ax.set_xticks(bin_centers.astype(int))
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.legend();

--- a/notebooks/novel-recombinants-analysis.ipynb
+++ b/notebooks/novel-recombinants-analysis.ipynb
@@ -17,28 +17,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d0fbf845-0ae3-4900-b390-1a4547c0fd91",
-   "metadata": {},
-   "source": [
-    "## Dependencies\n",
-    "\n",
-    "1. **Install python dependencies using `conda` (or a `conda` derivative):**\n",
-    "\n",
-    "    ```bash\n",
-    "     micromamba env create -f notebooks/novel-recombinants-analysis.yml\n",
-    "    ```\n",
-    "\n",
-    "2. **Install conda environment as a jupyter kernel.**\n",
-    "\n",
-    "    ```bash\n",
-    "    python -m ipykernel install --user --name=novel-recombinants\n",
-    "    ```\n",
-    "\n",
-    "3. **Select `ncov-recombinants` kernel for this notebook.**"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "6ec150d0-e6cf-4c8e-923d-7aff91309923",
@@ -47,204 +25,32 @@
    "source": [
     "from pathlib import Path\n",
     "import collections\n",
-    "import os\n",
-    "\n",
     "import pandas as pd\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import nb_utils"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "41c2de93-2126-45c6-b4e6-8acc99e31f78",
+   "id": "bd3acbc5-1f2f-4be2-bcf6-7d2cd91d1e90",
    "metadata": {},
    "outputs": [],
    "source": [
-    "curr_dir = os.path.basename(os.getcwd())\n",
-    "\n",
-    "# If we're still in the notebooks directory, move up to the project root.\n",
-    "if curr_dir != \"sc2ts-paper\":\n",
-    "  sc2ts_dir = os.path.join(os.getcwd(), \"..\")\n",
-    "  _ = os.chdir(sc2ts_dir)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fbf95b4c-cb51-4fbb-b83b-8bce161c5356",
-   "metadata": {},
-   "source": [
-    "## Data\n",
-    "\n",
-    "- Viridan metadata: `data/run_metadata.v04.tsv.gz`\n",
-    "   - URL: https://figshare.com/articles/dataset/Supplementary_table_S1/25712982?file=45969195\n",
-    "- Viridian sequences: `data/Viridian_tree_cons_seqs/<#>.cons.fa.xz`\n",
-    "   - URL: https://doi.org/10.6084/m9.figshare.25713225\n",
-    "- Viridian index: `data/Viridian_tree_cons_seqs/index.tsv.xz`\n",
-    "\n",
-    "> **Note**: Keep files in their compressed form (`gz`, `xz`), we will use tools that don't need decompression first."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9e776e19-1c46-4f15-b484-7be1856270ed",
-   "metadata": {},
-   "source": [
-    "Change the working directory to the root of the `sc2ts-paper` project."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0ed6fc1e-af3f-4a07-807f-f30562892b6d",
-   "metadata": {},
-   "source": [
-    "Setup input/output files and directories."
+    "data_dir = Path(\"../data\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "bd3acbc5-1f2f-4be2-bcf6-7d2cd91d1e90",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data_dir = Path(\"data\")\n",
-    "dataset_dir = Path(\"notebooks/dataset\")\n",
-    "results_dir = Path(\"results\")\n",
-    "\n",
-    "metadata = data_dir / \"run_metadata.v04.tsv.gz\"\n",
-    "sequences = data_dir / \"Viridian_tree_cons_seqs\"\n",
-    "index = data_dir / \"Viridian_tree_cons_seqs\" / \"index.tsv.xz\"\n",
-    "recombinants = data_dir / \"recombinants.csv\"\n",
-    "results = results_dir / \"novel_recombinants\"\n",
-    "nextclade_dataset = dataset_dir / \"nextclade\"\n",
-    "\n",
-    "if not os.path.exists(results):\n",
-    "  os.makedirs(results)\n",
-    "if not os.path.exists(nextclade_dataset):\n",
-    "  os.makedirs(nextclade_dataset)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "77ae0623-7fb0-42d3-bc62-ac03053b601f",
-   "metadata": {},
-   "source": [
-    "## Dependencies"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1355f595-ddf3-44a8-8ce9-535722dd5293",
-   "metadata": {},
-   "source": [
-    "### Install csvtk\n",
-    "\n",
-    "`csvtk` is used as a unix-based dataframe engine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2b79ede9-d7fc-4bf2-951c-ef3a2035c636",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! wget -q -O csvtk.tar.gz https://github.com/shenwei356/csvtk/releases/download/v0.32.0/csvtk_linux_386.tar.gz\n",
-    "! tar -xf csvtk.tar.gz\n",
-    "! mv csvtk bin/\n",
-    "! rm -f csvtk.tar.gz\n",
-    "! bin/csvtk --help | head -n 5"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "be2832ac-2d8b-4bb3-9843-3a9b10c0bf59",
-   "metadata": {},
-   "source": [
-    "### Install seqkit\n",
-    "\n",
-    "`seqkit` is a unix-based tool for sequence queries and manipulation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8ce11a03-cf83-450d-b5b7-16cf2c817fc5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! wget -q -O seqkit.tar.gz https://github.com/shenwei356/seqkit/releases/download/v2.9.0/seqkit_linux_amd64.tar.gz\n",
-    "! tar -xf seqkit.tar.gz\n",
-    "! mv seqkit bin/\n",
-    "! rm -f seqkit.tar.xz\n",
-    "! bin/seqkit --help | head -n 5"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "73c4d4cb-bf8a-4c3e-88b8-3bd9a7be743b",
-   "metadata": {},
-   "source": [
-    "### Install nextclade\n",
-    "\n",
-    "`nextclade` is a unix-based tool for sequence alignment and lineage assignment."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4497dc52-6bd0-444b-989a-1089fcc6e185",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! wget -q -O bin/nextclade https://github.com/nextstrain/nextclade/releases/download/3.10.2/nextclade-x86_64-unknown-linux-musl\n",
-    "! bin/nextclade --help | head -n 5"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4c3c8e44-f0a6-43c9-91d8-d55fbab1700a",
-   "metadata": {},
-   "source": [
-    "### Install rebar\n",
-    "\n",
-    "`rebar` is a unix-based tool for recombinant sequence detection."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cc0855df-0405-4ae3-bb9a-9de3648a2f61",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! wget -q -O bin/rebar https://github.com/phac-nml/rebar/releases/download/v0.2.1/rebar-x86_64-unknown-linux-musl\n",
-    "! bin/rebar --help | head -n 5"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "953edd18-3e2f-4be6-8f80-05314acf9539",
-   "metadata": {},
-   "source": [
-    "### Install pangonet\n",
-    "\n",
-    "`pangonet` is a python package and CLI tool for manipulating SARS-CoV-2 lineages in a recombination-aware, phylogenetic network.\n",
-    "\n",
-    "Mainly, it's useful for getting ancestral/descendant relationships of lineages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "e448d03b-3ad4-4a5f-afab-1700b17f0f4a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "! git clone https://github.com/phac-nml/pangonet.git\n",
-    "! cd pangonet && pip install . && cd -\n",
-    "! pangonet --help | head"
+    "#! git clone https://github.com/phac-nml/pangonet.git\n",
+    "#! cd pangonet && pip install . && cd -\n",
+    "#! pangonet --help | head"
    ]
   },
   {
@@ -257,212 +63,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-04-08 10:47:28,130 INFO:Creating aliases.\n",
-      "2025-04-08 10:47:28,134 INFO:Creating network.\n"
+      "2025-04-12 22:05:07,451 INFO:Creating aliases.\n",
+      "2025-04-12 22:05:07,463 INFO:Creating network.\n"
      ]
     }
    ],
    "source": [
-    "from pangonet.pangonet import PangoNet\n",
-    "\n",
-    "alias_key_path = os.path.join(\"notebooks\", \"dataset\", \"rebar\", \"alias_key.json\")\n",
-    "lineage_notes_path = os.path.join(\"notebooks\", \"dataset\", \"rebar\", \"lineage_notes.txt\")\n",
-    "pango = PangoNet().build(alias_key=alias_key_path, lineage_notes=lineage_notes_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1cb48dc9-d8d5-4f18-a023-d43794d30cee",
-   "metadata": {},
-   "source": [
-    "## Metadata and Sequences\n",
-    "\n",
-    "Extract Viridian metadata for the novel recombinants."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8b8f4550-58f7-4215-ad69-a75d7746fefc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! bin/csvtk cut -f sample_id {recombinants} \\\n",
-    "  | tail -n+2 \\\n",
-    "  | bin/csvtk grep -t -f Run -P - {metadata} \\\n",
-    "  | bin/csvtk merge -t -f Run {index} - | \\\n",
-    "  > {results}/metadata.tsv\n",
-    "\n",
-    "pd.read_csv(f\"{results}/metadata.tsv\", sep=\"\\t\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5b368f56-ef98-448e-8a5d-4d63a3540a39",
-   "metadata": {},
-   "source": [
-    "Extract Viridian batch numbers for the novel recombinants."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "914099fa-e000-4122-935f-077135936910",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! bin/csvtk cut -t -f Batch {results}/metadata.tsv | tail -n+2 | sort -g | uniq > {results}/batches.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ac70088e-698d-4860-ae8b-3c5f2eb17030",
-   "metadata": {},
-   "source": [
-    "Extract Viridian consensus sequences for the novel recombinants."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "737ca1ef-c1d6-4dda-b7e7-7153ed561625",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! cat results/novel_recombinants/batches.txt | while read batch; do \\\n",
-    "  echo Batch: ${batch} 1>&2; \\\n",
-    "  bin/csvtk grep -t -f Batch -p ${batch} results/novel_recombinants/metadata.tsv \\\n",
-    "    | bin/csvtk cut -t -f Run \\\n",
-    "    | tail -n+2 \\\n",
-    "    | bin/seqkit grep -w 0 -f - data/Viridian_tree_cons_seqs/${batch}.cons.fa.xz; \\\n",
-    "done > results/novel_recombinants/sequences.fasta"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ba18f4da-b56f-43c0-a85d-174911a9eae8",
-   "metadata": {},
-   "source": [
-    "## Align"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "98eeee60-44b6-4a55-a6d9-d69d009e3b7c",
-   "metadata": {},
-   "source": [
-    "Download the sars-cov-2 lineage model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9a9b4e2f-fad8-467f-b92e-b8334d28928e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! bin/nextclade dataset get \\\n",
-    "  --name sars-cov-2 \\\n",
-    "  --tag  2025-01-28--16-39-09Z \\\n",
-    "  --output-dir dataset/nextclade"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f77701b0-ea13-41b8-a7ad-bbe5cec45acb",
-   "metadata": {},
-   "source": [
-    "Align the sequences."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a988993f-e037-4dbf-8c67-579eb275b25d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! bin/nextclade run \\\n",
-    "  --input-dataset dataset/nextclade \\\n",
-    "  --jobs 2 \\\n",
-    "  --output-tsv {results}/nextclade.tsv \\\n",
-    "  --output-fasta {results}/nextclade.fasta \\\n",
-    "  {results}/sequences.fasta"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dc0b8df8-6636-4755-a8e4-121c4f017103",
-   "metadata": {},
-   "source": [
-    "### Detect Recombination"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7f6719a0-a400-4922-a82e-78e659d72eda",
-   "metadata": {},
-   "source": [
-    "Download the sars-cov-2 lineage model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c64dab64-7556-4860-9f3a-669027893600",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! bin/rebar dataset download \\\n",
-    "  --name sars-cov-2 \\\n",
-    "  --tag 2025-01-28 \\\n",
-    "  --verbosity error \\\n",
-    "  --output-dir dataset/rebar"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dcaa86a0-038c-429d-8931-8775e83e564d",
-   "metadata": {},
-   "source": [
-    "Detection recombination in the sequences."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6c1bc68c-452d-4c40-97b9-14dac0eeb8e7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! bin/rebar run \\\n",
-    "  --dataset-dir dataset/rebar \\\n",
-    "  --threads 2 \\\n",
-    "  --alignment {results}/nextclade.fasta \\\n",
-    "  --output-dir {results}/rebar\n",
-    "\n",
-    "! cp {results}/rebar/linelist.tsv data/rebar.tsv"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "08f3a1d3-9fb6-4e5e-a27b-41b6b05706fd",
-   "metadata": {},
-   "source": [
-    "Plot parents and breakpoints."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c6bf8447-a28e-4fec-af3e-c40562d069c9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! bin/rebar plot \\\n",
-    "  --run-dir {results}/rebar \\\n",
-    "  --annotations dataset/rebar/annotations.tsv \\\n",
-    "  --verbosity error"
+    "dataset_dir = Path(\"dataset\")\n",
+    "alias_key_file = dataset_dir / \"rebar\" / \"alias_key.json\"\n",
+    "lineage_notes_file = dataset_dir / \"rebar\" / \"lineage_notes.txt\"\n",
+    "pangonet = nb_utils.initialise_pangonet(alias_key_file, lineage_notes_file)"
    ]
   },
   {
@@ -566,39 +176,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "e23845b8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def plot_stacked_histogram(a, b, alegend, blegend, xlabel, ylabel, xlim):\n",
-    "    bin_edges = np.arange(xlim[0], xlim[1])\n",
-    "    hist_a, _ = np.histogram(a, bins=bin_edges)\n",
-    "    hist_b, _ = np.histogram(b, bins=bin_edges)\n",
-    "    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2 - 0.5\n",
-    "    bar_width = 0.8\n",
-    "    _, ax = plt.subplots()\n",
-    "    _ = ax.bar(\n",
-    "        bin_centers,\n",
-    "        hist_a,\n",
-    "        width=bar_width,\n",
-    "        label=alegend,\n",
-    "    )\n",
-    "    _ = ax.bar(\n",
-    "        bin_centers,\n",
-    "        hist_b,\n",
-    "        bottom=hist_a,\n",
-    "        width=bar_width,\n",
-    "        label=blegend,\n",
-    "    )\n",
-    "    ax.set_xticks(bin_centers.astype(int))\n",
-    "    ax.set_xlabel(xlabel)\n",
-    "    ax.set_ylabel(ylabel)\n",
-    "    ax.legend();"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "f220af95-5df3-473b-b335-cc3d89ffc4aa",
    "metadata": {},
@@ -608,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "3f966f06",
    "metadata": {},
    "outputs": [
@@ -618,7 +195,7 @@
        "161"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -637,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "6ba3f42e",
    "metadata": {},
    "outputs": [
@@ -656,7 +233,7 @@
     "novel_max_run_len = dfj[dfj[\"recombinant_rebar\"] == \"novel\"].max_run_length\n",
     "nonnovel_max_run_len = dfj[dfj[\"recombinant_rebar\"] != \"novel\"].max_run_length\n",
     "\n",
-    "plot_stacked_histogram(\n",
+    "nb_utils.plot_stacked_histogram(\n",
     "    a=novel_max_run_len,\n",
     "    b=nonnovel_max_run_len,\n",
     "    alegend='Novel as per rebar',\n",
@@ -677,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "663b1dbd-610a-485c-a71e-74a3202c4233",
    "metadata": {
     "scrolled": true
@@ -689,7 +266,7 @@
        "578"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -702,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "56768cd0-64e1-4db7-b2f3-86a4b8141222",
    "metadata": {},
    "outputs": [
@@ -909,7 +486,7 @@
        "XCT          1"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -933,7 +510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "935ecf61-b184-4bba-8387-a7842ab1fcb3",
    "metadata": {},
    "outputs": [
@@ -943,7 +520,7 @@
        "355"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -956,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "8a157690-4eae-4630-9ec9-4c439721350b",
    "metadata": {
     "scrolled": true
@@ -968,7 +545,7 @@
        "223"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -989,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "8b05603a",
    "metadata": {},
    "outputs": [],
@@ -1001,7 +578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "09e4dd5c",
    "metadata": {},
    "outputs": [
@@ -1011,7 +588,7 @@
        "0"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1023,7 +600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "905c9727",
    "metadata": {},
    "outputs": [
@@ -1033,7 +610,7 @@
        "7"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1045,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "c10fef19",
    "metadata": {},
    "outputs": [
@@ -1055,7 +632,7 @@
        "216"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1071,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "f7d1a191",
    "metadata": {},
    "outputs": [
@@ -1081,7 +658,7 @@
        "213"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1125,7 +702,7 @@
     "    # Check for equivalent or sister taxa\n",
     "    p1, p2 = row[\"parent_left_pango\"], row[\"parent_right_pango\"]\n",
     "    if p1 == p2: continue\n",
-    "    anc, desc = pango.get_ancestors(p1), pango.get_descendants(p1)\n",
+    "    anc, desc = pangonet.get_ancestors(p1), pangonet.get_descendants(p1)\n",
     "    if p2 in anc or p2 in desc: continue         \n",
     "    is_rebar_candidate[i] = True\n",
     "\n",
@@ -1143,7 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "e8772b32",
    "metadata": {},
    "outputs": [],
@@ -1157,7 +734,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "df9fe240-04e9-4263-aab3-2fb12d3ec9be",
    "metadata": {},
    "outputs": [],
@@ -1168,8 +745,8 @@
     "    concordant_count = 0\n",
     "    for p in [\"left\", \"right\"]:\n",
     "        p_rebar = row[f\"parent_{p}_rebar\"]\n",
-    "        anc_rebar = pango.get_ancestors(p_rebar)\n",
-    "        desc_rebar = pango.get_descendants(p_rebar)\n",
+    "        anc_rebar = pangonet.get_ancestors(p_rebar)\n",
+    "        desc_rebar = pangonet.get_descendants(p_rebar)\n",
     "        p_sc2ts = row[f\"parent_{p}_pango\"]\n",
     "\n",
     "        concordant = (p_rebar == p_sc2ts) or \\\n",
@@ -1188,7 +765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "db952228-aebd-4998-a3a9-a0345fb70771",
    "metadata": {},
    "outputs": [
@@ -1208,7 +785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "7a216dbc",
    "metadata": {},
    "outputs": [
@@ -1604,7 +1181,7 @@
        "ERR10839902         XBB.1.5.18                XCE  "
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1634,7 +1211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "id": "171bb349",
    "metadata": {},
    "outputs": [
@@ -1800,7 +1377,7 @@
        "[213 rows x 5 columns]"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1873,7 +1450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "id": "09948367-d0e7-4c0c-9dc8-45a698d8d1b2",
    "metadata": {},
    "outputs": [
@@ -1893,7 +1470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "id": "80062211",
    "metadata": {},
    "outputs": [],
@@ -1913,7 +1490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "id": "ac5dff6d",
    "metadata": {},
    "outputs": [
@@ -1934,7 +1511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "id": "2c4ccb19",
    "metadata": {},
    "outputs": [
@@ -1958,7 +1535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "id": "c909877c",
    "metadata": {},
    "outputs": [
@@ -1982,7 +1559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "id": "a84dcbbf",
    "metadata": {},
    "outputs": [
@@ -2255,7 +1832,7 @@
        "SRR21868921             2329.0  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2289,28 +1866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "f211e76b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_node_distance(pango_1, pango_2):\n",
-    "    mrca = pango.get_mrca([pango_1, pango_2])\n",
-    "    assert len(mrca) == 1\n",
-    "    # Paths include the start and end nodes\n",
-    "    mrca_pango_1_path = pango.get_paths(start=pango_1, end=mrca[0])\n",
-    "    mrca_pango_2_path = pango.get_paths(start=pango_2, end=mrca[0])\n",
-    "    assert len(mrca_pango_1_path) == 1\n",
-    "    assert len(mrca_pango_2_path) == 1\n",
-    "    mrca_pango_1_distance = len(mrca_pango_1_path[0]) - 1\n",
-    "    mrca_pango_2_distance = len(mrca_pango_2_path[0]) - 1\n",
-    "    node_distance = mrca_pango_1_distance + mrca_pango_2_distance\n",
-    "    return node_distance"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "id": "66bf5ab7-b08b-467c-8f9f-fbb9a36a95c4",
    "metadata": {},
    "outputs": [],
@@ -2323,16 +1879,17 @@
     "    if row[\"parent_left_pango\"].startswith(\"X\") or row[\"parent_right_pango\"].startswith(\"X\"):\n",
     "        node_dist.append(-1)\n",
     "        continue\n",
-    "    d = get_node_distance(\n",
-    "        pango_1=row[\"parent_left_pango\"],\n",
-    "        pango_2=row[\"parent_right_pango\"],\n",
+    "    d = nb_utils.get_node_distance(\n",
+    "        pangonet=pangonet,\n",
+    "        label_1=row[\"parent_left_pango\"],\n",
+    "        label_2=row[\"parent_right_pango\"],\n",
     "    )\n",
     "    node_dist.append(d)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 31,
    "id": "a90da1a9",
    "metadata": {},
    "outputs": [
@@ -2342,7 +1899,7 @@
        "12"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2354,7 +1911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 32,
    "id": "586d073a",
    "metadata": {},
    "outputs": [
@@ -2484,7 +2041,7 @@
        "[1 rows x 37 columns]"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2497,7 +2054,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 33,
    "id": "6b707139",
    "metadata": {},
    "outputs": [
@@ -2516,7 +2073,7 @@
     "recomb_nd = df_hq_nd[~df_hq_nd[\"recombinant_rebar\"].isna()].node_distance\n",
     "nonrecomb_nd = df_hq_nd[df_hq_nd[\"recombinant_rebar\"].isna()].node_distance\n",
     "\n",
-    "plot_stacked_histogram(\n",
+    "nb_utils.plot_stacked_histogram(\n",
     "    a=recomb_nd,\n",
     "    b=nonrecomb_nd,\n",
     "    alegend='Recombinant as per rebar',\n",
@@ -2537,7 +2094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 34,
    "id": "e74ec420",
    "metadata": {},
    "outputs": [
@@ -2557,7 +2114,7 @@
     "rebar_nonrecomb = df_hq[is_rebar_recomb].num_mutations_averted\n",
     "rebar_recomb = df_hq[~is_rebar_recomb].num_mutations_averted\n",
     "\n",
-    "plot_stacked_histogram(\n",
+    "nb_utils.plot_stacked_histogram(\n",
     "    a=rebar_recomb,\n",
     "    b=rebar_nonrecomb,\n",
     "    alegend='Recombinant as per rebar',\n",

--- a/notebooks/run_rebar_on_recombinants.sh
+++ b/notebooks/run_rebar_on_recombinants.sh
@@ -1,0 +1,101 @@
+### Install Dependencies
+micromamba env create -f notebooks/novel-recombinants-analysis.yml
+
+python -m ipykernel install --user --name=novel-recombinants
+
+### Download data.
+# - Viridan metadata: `data/run_metadata.v04.tsv.gz`
+#   - URL: https://figshare.com/articles/dataset/Supplementary_table_S1/25712982?file=45969195
+# - Viridian sequences: `data/Viridian_tree_cons_seqs/<#>.cons.fa.xz`
+#   - URL: https://doi.org/10.6084/m9.figshare.25713225
+# - Viridian index: `data/Viridian_tree_cons_seqs/index.tsv.xz`
+
+### Download dependencies.
+wget -q -O csvtk.tar.gz https://github.com/shenwei356/csvtk/releases/download/v0.32.0/csvtk_linux_386.tar.gz
+tar -xf csvtk.tar.gz
+mv csvtk bin/
+rm -f csvtk.tar.gz
+#bin/csvtk --help | head -n 5
+
+wget -q -O seqkit.tar.gz https://github.com/shenwei356/seqkit/releases/download/v2.9.0/seqkit_linux_amd64.tar.gz
+tar -xf seqkit.tar.gz
+mv seqkit bin/
+rm -f seqkit.tar.xz
+#bin/seqkit --help | head -n 5
+
+wget -q -O bin/nextclade https://github.com/nextstrain/nextclade/releases/download/3.10.2/nextclade-x86_64-unknown-linux-musl
+#bin/nextclade --help | head -n 5
+
+wget -q -O bin/rebar https://github.com/phac-nml/rebar/releases/download/v0.2.1/rebar-x86_64-unknown-linux-musl
+#bin/rebar --help | head -n 5
+
+data_dir = "data"
+results_dir = "results"
+
+metadata_file = ${data_dir}"/run_metadata.v04.tsv.gz"
+sequences = ${data_dir}"/Viridian_tree_cons_seqs"
+index_file = ${data_dir}"/Viridian_tree_cons_seqs/index.tsv.xz"
+recombinants_file = ${data_dir}"/recombinants.csv"
+
+# Extract Viridian metadata for the novel recombinants.
+bin/csvtk cut -f sample_id ${recombinants_file} \
+    tail -n+2 \
+    bin/csvtk grep -t -f Run -P - ${metadata_file} \
+    bin/csvtk merge -t -f Run ${index_file} - | \
+    > results/novel_recombinants/metadata.tsv
+
+# Extract Viridian batch numbers for the novel recombinants.
+bin/csvtk cut -t -f Batch ${results_dir}"/metadata.tsv" | \
+    tail -n+2 | \
+    sort -g | \
+    uniq > results/novel_recombinants//batches.txt
+
+# Extract Viridian consensus sequences for the novel recombinants.
+cat results/novel_recombinants/batches.txt | \
+    while read batch; do \
+    echo Batch: ${batch} 1>&2; \
+    bin/csvtk grep -t -f Batch -p ${batch} results/novel_recombinants/metadata.tsv \
+        | bin/csvtk cut -t -f Run \
+        | tail -n+2 \
+        | bin/seqkit grep -w 0 -f - "data/Viridian_tree_cons_seqs/"${batch}".cons.fa.xz"; \
+    done > results/novel_recombinants/sequences.fasta
+
+# Download the sars-cov-2 lineage model.
+bin/nextclade dataset get \
+    --name sars-cov-2 \
+    --tag  2025-01-28--16-39-09Z \
+    --output-dir dataset/nextclade
+
+# Align the sequences.
+bin/nextclade run \
+    --input-dataset dataset/nextclade \
+    --jobs 2 \
+    --output-tsv results/novel_recombinants/nextclade.tsv \
+    --output-fasta results/novel_recombinants/nextclade.fasta \
+    results/novel_recombinants/sequences.fasta
+
+# Detect recombination using rebar.
+bin/rebar dataset download \
+    --name sars-cov-2 \
+    --tag 2025-01-28 \
+    --verbosity error \
+    --output-dir dataset/rebar
+
+bin/rebar dataset download \
+    --name sars-cov-2 \
+    --tag 2025-01-28 \
+    --verbosity error \
+    --output-dir dataset/rebar
+
+bin/rebar run \
+    --dataset-dir dataset/rebar \
+    --threads 2 \
+    --alignment results/novel_recombinants/nextclade.fasta \
+    --output-dir results/novel_recombinants/rebar
+
+cp results/novel_recombinants/rebar/linelist.tsv data/rebar.tsv
+
+bin/rebar plot \
+    --run-dir results/novel_recombinants/rebar \
+    --annotations dataset/rebar/annotations.tsv \
+    --verbosity error


### PR DESCRIPTION
* Moved the bash commands used to install dependencies and to run nextclade and rebar to a single bash script (`run_rebar_on_recombinants.sh`). I find them rather distracting to be in the notebook.
* Moved function to plot stacked histograms to `nb_utils`.
* Tidy up and use routines in `nb_utils` (e.g., `get_node_distance`).