### PR TITLE
Generate decent dates based on samples

### DIFF
--- a/usher_tree/Snakefile
+++ b/usher_tree/Snakefile
@@ -59,11 +59,23 @@ rule add_mutations:
         python ../src/mat2tsk.py convert-mutations {input} reference.fasta {output}
         """
 
-rule minimise_metadata:
+rule date_sammples:
     conda:
         "convert.yml"
     input:
         "viridian.mutations.trees",
+    output:
+        "viridian.dated_samples.trees"
+    shell:
+        """
+        python ../src/mat2tsk.py date-samples {input} {output}
+        """
+
+rule minimise_metadata:
+    conda:
+        "convert.yml"
+    input:
+        "viridian.dated_samples.trees",
     output:
         "all_viridian.202409.trees"
     shell:


### PR DESCRIPTION
Date nodes in the usher tree based on sample dates. Assumes that internal nodes are 1 day older than their oldest child, which is probably fine for most cases.

Dropping 25306 samples without exact dates as they are not worth the trouble.