### PR TITLE
Load in the .vcz file

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,3 +1,4 @@
 *.tsz
+*.vcz.zip
 consensus_mutations.json
 *.nex

--- a/notebooks/nb_utils.py
+++ b/notebooks/nb_utils.py
@@ -33,7 +33,7 @@ def load(filename="sc2ts_viridian_v1.1.trees.tsz"):
     return ts
 
 
-def load_dataset(filename="viridian_mafft_2024-10-14_v1.vcz.zip"):
+def load_dataset(filename="viridian_mafft_2024-10-14_v1.vcz"):
     return sc2ts.Dataset(os.path.join(TSDIR, filename), date_field="Date_tree")
 
 


### PR DESCRIPTION
Even if in .zip format, you load an sc2ts dataset without specifying the .zip extension, so the default value should not have it.