### PR TITLE
Initial pass on tables for copying patterns

### DIFF
--- a/latex/main.tex
+++ b/latex/main.tex
@@ -405,8 +405,6 @@ typically followed by visual analysis of genome sequence alignments
 to identify parental lineages and breakpoint locations.
 This process has resulted in the designation of recombinant Pango lineages
 (whose aliases begin with an ''X'', e.g., XA and XBB).
-Below, we summarize our analysis of the Pango X lineages in the ARG
-(for extended analyses, see Document~\ref{sec:supplement_pango_lineages} and Document S2).
 
 We find strong evidence for the recombination events leading to 17 Pango X lineages
 in the ARG (Table~\ref{tab:pango_x_lineages}),
@@ -447,6 +445,12 @@ and one mutation in the ARG, respectively (Figure~\ref{fig:subgraphs}C).
 However, sc2ts did not detect several Pango X lineages (XB, XP, and XAJ) as recombinants
 because the HMM treated characteristic deletions as missing data.
 
+
+[NOTE: putting this here for now, until we find the right place to slot it
+in next draft.]
+See Document~\ref{sec:supplement_pango_lineages} for extended analyses,
+Figure~\ref{fig:pango_x_copying_patterns} for copying patterns,
+and Document S2 for ARG visualations of all Pango X lineages.
 
 \begin{figure}[h]
 \centering
@@ -1588,7 +1592,11 @@ to enrich the ARG with additional information:
 \subsubsection*{Identification of robust recombination events}
 
 [TODO This section needs a full pass. I've merged in a section that was in the
-supplement with an extremely terse section on counting supporting loci.]
+supplement with an extremely terse section on counting supporting loci.
+Reference Figure~\ref{fig:recombinant_qc} for the scatter plot and 
+labelled quadrants, and Figure~\ref{fig:copying_pattern_examples}
+for examples of the corresponding copying patterns. Also reference
+any additional examples that we include beyond A-D.]
 
 % This para was *{Counting supporting loci for recombinant parents}
 


### PR DESCRIPTION
Opening this for visibility (not quite happy with how it looks, but need to leave it for tonight). Looks like this:

<img width="663" height="926" alt="Screenshot from 2025-09-12 21-57-10" src="https://github.com/user-attachments/assets/195e997d-ec90-45ce-bcf3-7f94317926e7" />
<img width="590" height="534" alt="Screenshot from 2025-09-12 21-57-20" src="https://github.com/user-attachments/assets/e1094800-2672-4c69-981c-a48de0ec60dc" />

I think this is enough by the way, and compiling copying patterns for more of the recombinants is overkill for submission.