### PR TITLE
Save tsdate metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pyc
 *-checkpoint.ipynb
+*/.ipynb_checkpoints/*
+*/.jupyter/*
 .DS_Store
 env
 

--- a/arg_postprocessing/Snakefile
+++ b/arg_postprocessing/Snakefile
@@ -303,7 +303,7 @@ rule date:
         "{DATE_PREFIX}_dated.trees",
     shell:
         """
-        python scripts/run_nonsample_dating.py {input} {output}
+        python scripts/run_nonsample_dating.py {input} {output} --add-tsdate-metadata
         """
 
 


### PR DESCRIPTION
This will make the intermediate .tsz files bigger, but maybe it's fine. I'm not sure how we pass all this through in the final `Minimise metadata` step?