### PR TITLE
Update sc2ts.yml

### DIFF
--- a/arg_postprocessing/sc2ts.yml
+++ b/arg_postprocessing/sc2ts.yml
@@ -241,9 +241,7 @@ dependencies:
       - scipy==1.15.3
       - sortedcontainers==2.4.0
       - tqdm==4.67.1
-      - tskit==1.0.0b3
       - tsdate==0.2.3
       - -e git+https://github.com/phac-nml/pangonet.git#egg=pangonet
       # FIXME change to released version when it is done
-      - -e git+https://github.com/jeromekelleher/sc2ts.git#egg=sc2ts[inference,debug]
-# This is a counter to force an update: 19
+      - -e git+https://github.com/jeromekelleher/sc2ts.git#egg=sc2ts[inference,debug]      


### PR DESCRIPTION
Fix #1033

Got rid of sc2ts dependencies which are installed when installing sc2ts.

It works on my machine without these messages:
```
DEPRECATION: git+https://github.com/jeromekelleher/sc2ts.git#egg=sc2ts[inference,debug] contains an egg fragment with a non-PEP 508 name. pip 25.2 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at https://github.com/pypa/pip/issues/13157
  Running command git clone --filter=blob:none --quiet https://github.com/phac-nml/pangonet.git /gpfs3/well/kelleher/users/nrn539/sc2ts_revision/sc2ts-paper/arg_postprocessing/.snakemake/conda/src/pangonet
DEPRECATION: git+https://github.com/jeromekelleher/sc2ts.git#egg=sc2ts[inference,debug] contains an egg fragment with a non-PEP 508 name. pip 25.2 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at https://github.com/pypa/pip/issues/13157
  Running command git clone --filter=blob:none --quiet https://github.com/jeromekelleher/sc2ts.git /gpfs3/well/kelleher/users/nrn539/sc2ts_revision/sc2ts-paper/arg_postprocessing/.snakemake/conda/src/sc2ts
ERROR: Cannot install sc2ts and tskit==1.0.0b3 because these package versions have conflicting dependencies.
```