### PR TITLE
Fix bug introduced when skipping multiparent recombinants

### DIFF
--- a/arg_postprocessing/scripts/run_breakpoint_shift_for_deletions.py
+++ b/arg_postprocessing/scripts/run_breakpoint_shift_for_deletions.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
     ts = tszip.load(args.input_ts)
 
     re_nodes = np.where(ts.nodes_flags & sc2ts.NODE_IS_RECOMBINANT)[0]
+    tmp_re_nodes = []
     recombinant_edges = []
     for c in re_nodes:
         re_edges = np.where(ts.edges_child == c)[0]
@@ -39,7 +40,9 @@ if __name__ == "__main__":
             # Skip multi-parent recombinants.
             continue
         assert len(re_edges) == 2
+        tmp_re_nodes.append(c)
         recombinant_edges.append(re_edges)
+    re_nodes = np.array(tmp_re_nodes)
     recombinant_edges = np.array(recombinant_edges)
     # Sort the edges for each child so the left one is first
     srt = np.argsort(ts.edges_left[recombinant_edges], axis=1)


### PR DESCRIPTION
Dimensions don't match when doing:
```
child_and_parents = np.column_stack([re_nodes, recombinant_parents])
```