### PR TITLE
Skip multiparent recombinants when getting min length

### DIFF
--- a/arg_postprocessing/scripts/add_recombinant_minlength_to_csv.py
+++ b/arg_postprocessing/scripts/add_recombinant_minlength_to_csv.py
@@ -79,6 +79,9 @@ def main(args):
     )
     arr = []
     for u, support in supporting_loci_count.items():
+        if len(support) > 2:
+            # Skip multiparent recombinants.
+            continue
         if len(support) != 2:
             raise ValueError(
                 f"Expected 2 edges above recombinant node {u} but found "


### PR DESCRIPTION
Yan was hitting this error when running the postprocess pipeline.

```python
Traceback (most recent call last):
  File "/gpfs3/well/kelleher/users/nrn539/sc2ts_revision/sc2ts-paper/arg_postprocessing/scripts/add_recombinant_minlength_to_csv.py", line 142, in <module>
    main(args)
  File "/gpfs3/well/kelleher/users/nrn539/sc2ts_revision/sc2ts-paper/arg_postprocessing/scripts/add_recombinant_minlength_to_csv.py", line 83, in main
    raise ValueError(
ValueError: Expected 2 edges above recombinant node 233437 but found  4, implying it does not have exactly 2 parents
```