### PR TITLE
Use .tsz for Snakefile rematch_recombinants

### DIFF
--- a/arg_postprocessing/Snakefile
+++ b/arg_postprocessing/Snakefile
@@ -150,7 +150,7 @@ rule rematch_recombinants:
     shell:
         """
         python scripts/rematch_recombinants.py {input} \
-            --pattern=../inference/results/v2_2026-04-17/v2_2026-04-17_{{date}}.ts \
+            --pattern=../inference/results/v2_2026-04-17/v2_2026-04-17_{{date}}.ts.tsz \
             {output}
         """
 


### PR DESCRIPTION
See https://github.com/jeromekelleher/sc2ts-paper/issues/1048. Assumes that we have run `tszip [infedir]/*.ts` beforehand to compress all the files (can save hundreds of GB)