### PR TITLE
Dated final args

### DIFF
--- a/arg_postprocessing/Snakefile
+++ b/arg_postprocessing/Snakefile
@@ -27,7 +27,7 @@ rule all:
         # Rewiring recombinants report
         "logs/sc2ts_v2_2024-06-06_rewire-recombinants-report.ipynb",
         # Comparison between sc2ts and usher ARGs
-        "logs/usher_sc2ts_comparison.ipynb",
+        "logs/usher_sc2ts_comparison_2024-06-06.ipynb",
         # Deletion events.
         "sc2ts_v2_2024-06-06_pr_pp_mp_aph_bps_pango_dated_deletion_events.csv",
         # Recombinant data. Suffixes after _recombinants denote the operations
@@ -41,16 +41,18 @@ rule all:
         # Events corresponding to Pango X lineages. This is the pango_x_events.csv file
         # in the top-level data directory
         "sc2ts_v2_2024-06-06_pr_pp_mp_aph_bps_pango_dated_mmps_pango_x_events.csv",
-        "logs/final_arg_report.ipynb",
+        "logs/final_arg_report_2024-06-06.ipynb",
         # Intersection file needed for ripples analyses
         "usher_intersection_2024-06-06.pb",
         # These will run ripples and do the data processing
         "sc2ts_viridian_v2.0_ripples_p4.csv",
         "sc2ts_viridian_v2.0_ripples_p3.csv",
 
-rule final_args:
-    conda: 
+rule final_arg_report:
+    conda:
         "sc2ts.yml"
+    wildcard_constraints:
+        DATE=r"\d{4}-\d{2}-\d{2}",
     input:
         # Final ARG
         # Order of operations:
@@ -62,23 +64,59 @@ rule final_args:
         # 6) Compute pango assignment (must be after parsimony mapping and heuristics)
         # 7) Dating (_dated)
         # 8) Minimise metadata (must be last step)
-        "sc2ts_v2_2024-06-06_pr_pp_mp_aph_bps_pango_dated_mmps.trees.tsz",
-        "usher_v1_2024-06-06_mm.trees.tsz",
-        "sc2ts_2024-06-06_intersection.trees.tsz",
-        "usher_2024-06-06_intersection_ds_di.trees.tsz",
-    output: 
-        # Version numbers - mainly driven by the sc2ts_viridian_v1 version
-        # as the others except usher_viridian are derived from this. These 
-        # are major.minor, with major versions meaning significant changes,
-        # minor being relatively minor tweaks to the ARG.
+        "sc2ts_v2_{DATE}_pr_pp_mp_aph_bps_pango_dated_mmps.trees.tsz",
+        "sc2ts_{DATE}_intersection.trees.tsz",
+        "usher_{DATE}_intersection_ds_di.trees.tsz",
+        # The full usher tree is date-independent and published separately
+        # (rule usher_viridian); the notebook loads it directly rather than
+        # copying it, so it is the last, unpaired input.
+        "usher_viridian.trees.tsz",
+    output:
+        # Dated copies of the final ARGs. The notebook copies the first three
+        # inputs to these outputs. The published version-numbered release names
+        # are derived from these by the release_args rule below.
+        "sc2ts_viridian_{DATE}.trees.tsz",
+        "sc2ts_viridian_inter_{DATE}.trees.tsz",
+        "usher_viridian_inter_{DATE}.trees.tsz",
+    log:
+        notebook="logs/final_arg_report_{DATE}.ipynb"
+    notebook:
+        "notebooks/final_arg_report.py.ipynb"
+
+# The full usher tree is a single fixed Sept-2024 snapshot, so it is
+# date-independent: publish it once under its (undated) viridian name.
+rule usher_viridian:
+    input:
+        "usher_v1_mm.trees.tsz",
+    output:
+        "usher_viridian.trees.tsz",
+    shell:
+        "cp {input} {output}"
+
+# Publish the dated final ARGs under their version-numbered release names.
+# Version numbers - mainly driven by the sc2ts_viridian_v1 version
+# as the others except usher_viridian are derived from this. These
+# are major.minor, with major versions meaning significant changes,
+# minor being relatively minor tweaks to the ARG. v2.0 / v1.0 correspond
+# to the 2024-06-06 data.
+rule release_args:
+    input:
+        "sc2ts_viridian_2024-06-06.trees.tsz",
+        "usher_viridian.trees.tsz",
+        "sc2ts_viridian_inter_2024-06-06.trees.tsz",
+        "usher_viridian_inter_2024-06-06.trees.tsz",
+    output:
         "sc2ts_viridian_v2.0.trees.tsz",
         "usher_viridian_v1.0.trees.tsz",
         "sc2ts_viridian_inter_v2.0.trees.tsz",
         "usher_viridian_inter_v2.0.trees.tsz",
-    log:
-        notebook="logs/final_arg_report.ipynb"
-    notebook:
-        "notebooks/final_arg_report.py.ipynb"
+    shell:
+        """
+        cp {input[0]} {output[0]}
+        cp {input[1]} {output[1]}
+        cp {input[2]} {output[2]}
+        cp {input[3]} {output[3]}
+        """
 
 rule initialise:
     input:
@@ -509,7 +547,10 @@ rule add_mutations:
         "usher_topology.trees",
         "usher_mutations.tsv"
     output:
-        "usher_v1_2024-06-06.trees"
+        # The usher tree is a single fixed Sept-2024 snapshot, so it is
+        # not date-dependent. Only the intersection with the dated sc2ts
+        # ARG (sc2ts_usher_intersection) carries a date.
+        "usher_v1.trees"
     shell:
         """
         python scripts/mat2tsk.py convert-mutations {input} reference.fasta {output}
@@ -519,7 +560,7 @@ rule date_samples:
     conda:
         "sc2ts.yml"
     input:
-        # Note: call with e.g. snakemake usher_v1_2024-06-06_ds.trees
+        # Note: call with e.g. snakemake usher_v1_ds.trees
         "{DS_PREFIX}.trees",
     output:
         "{DS_PREFIX}_ds.trees",
@@ -532,7 +573,7 @@ rule date_internal_nodes:
     conda:
         "sc2ts.yml"
     input:
-        # Note: call with e.g. snakemake usher_v1_2024-06-06_ds_di.trees
+        # Note: call with e.g. snakemake usher_v1_ds_di.trees
         "{DI_PREFIX}.trees"
     output:
         "{DI_PREFIX}_di.trees"
@@ -545,13 +586,15 @@ rule date_internal_nodes:
 rule sc2ts_usher_intersection:
     conda:
         "sc2ts.yml"
+    wildcard_constraints:
+        DATE=r"\d{4}-\d{2}-\d{2}",
     input:
-        "usher_v1_2024-06-06_mmd.trees",
+        "usher_v1_mmd.trees",
         # We use the final trees after post-processing and applying parsimony mapping
-        "sc2ts_v2_2024-06-06_pr_pp_mp_aph_mm.trees"
+        "sc2ts_v2_{DATE}_pr_pp_mp_aph_mm.trees"
     output:
-        "usher_2024-06-06_intersection.trees",
-        "sc2ts_2024-06-06_intersection.trees",
+        "usher_{DATE}_intersection.trees",
+        "sc2ts_{DATE}_intersection.trees",
     shell:
         """
         python scripts/mat2tsk.py intersect --intersect-sites {input} {output}
@@ -593,15 +636,17 @@ rule all_sites_parsimony:
 rule usher_sc2ts_comparison:
     conda:
         "sc2ts.yml"
+    wildcard_constraints:
+        DATE=r"\d{4}-\d{2}-\d{2}",
     input:
-        "usher_2024-06-06_intersection.trees",
-        "usher_2024-06-06_intersection_asp.trees",
-        "usher_2024-06-06_intersection_asp.csv",
-        "sc2ts_2024-06-06_intersection.trees",
-        "sc2ts_2024-06-06_intersection_asp.trees",
-        "sc2ts_2024-06-06_intersection_asp.csv",
+        "usher_{DATE}_intersection.trees",
+        "usher_{DATE}_intersection_asp.trees",
+        "usher_{DATE}_intersection_asp.csv",
+        "sc2ts_{DATE}_intersection.trees",
+        "sc2ts_{DATE}_intersection_asp.trees",
+        "sc2ts_{DATE}_intersection_asp.csv",
     log:
-        notebook="logs/usher_sc2ts_comparison.ipynb"
+        notebook="logs/usher_sc2ts_comparison_{DATE}.ipynb"
 
     notebook:
         "notebooks/usher_sc2ts_comparison.py.ipynb"

--- a/arg_postprocessing/notebooks/final_arg_report.py.ipynb
+++ b/arg_postprocessing/notebooks/final_arg_report.py.ipynb
@@ -18,11 +18,7 @@
    "id": "8b1fd0f6-a1be-4e93-8762-44f83ca6fb37",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "assert len(snakemake.input) == len(snakemake.output) == 4\n",
-    "for fin, fout in zip(snakemake.input, snakemake.output):\n",
-    "    shutil.copy(fin, fout)"
-   ]
+   "source": "# Copy the dated ARGs to their published viridian names. The full usher\n# tree (the last input) is date-independent and published separately, so\n# it is loaded directly below rather than copied here.\nassert len(snakemake.input) == 4 and len(snakemake.output) == 3\nfor fin, fout in zip(snakemake.input[:3], snakemake.output):\n    shutil.copy(fin, fout)"
   },
   {
    "cell_type": "code",
@@ -30,12 +26,7 @@
    "id": "4e5cac50-e5ee-41af-9fe5-742095ffc0bd",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "sc2ts_viridian = snakemake.output[0]\n",
-    "usher_viridian = snakemake.output[1]\n",
-    "sc2ts_viridian_inter = snakemake.output[2]\n",
-    "usher_viridian_inter = snakemake.output[3]"
-   ]
+   "source": "sc2ts_viridian = snakemake.output[0]\nsc2ts_viridian_inter = snakemake.output[1]\nusher_viridian_inter = snakemake.output[2]\n# The usher tree is published separately (undated) and passed as the last input.\nusher_viridian = snakemake.input[3]"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Makes it possible to run e.g.

```
snakemake -n logs/final_arg_report_2024-01-01.ipynb logs/usher_sc2ts_comparison_2024-01-01.ipynb


SNAKEMAKE
=========
  Date: 2026-06-02 21:12:45
  Workflow ID: 97e0a3e2-7dda-43b3-88a6-3a291d11620e
  Platform: Linux-6.8.0-117-generic-x86_64-with-glibc2.39
  Host: claude-worker1
  User: ubuntu
  Snakemake version: 9.22.0
  Python version: 3.11.15 (main, Mar  3 2026, 14:59:53) [Clang 21.1.4 ]
  Command: /home/ubuntu/.cache/uv/archive-v0/r13qX5gmwKWPuFmldse99/bin/snakemake -n logs/final_arg_report_2024-01-01.ipynb logs/usher_sc2ts_comparison_2024-01-01.ipynb
  Snakefile: /home/ubuntu/agents-work/sc2ts-paper/arg_postprocessing/Snakefile
  Base directory: /home/ubuntu/agents-work/sc2ts-paper/arg_postprocessing
  Run directory: /home/ubuntu/agents-work/sc2ts-paper/arg_postprocessing
  Working directory: /home/ubuntu/agents-work/sc2ts-paper/arg_postprocessing
  Config file(s): []
  Config MD5: 99914b932bd37a50b983c5e7c90ae93b

Building DAG of jobs...
Job stats:
job                                count
-------------------------------  -------
deletion_site_data                     1
download_json                          1
download_pb                            1
generate_all_sites                     1
initialise                             1
lineage_mutations                      1
convert_topology                       1
export_mutations_local                 1
rematch_recombinants_lbs               1
add_mutations                          1
rewire_recombinants                    1
minimise_metadata                      2
minimise_metadata_date                 1
postprocess                            1
generate_sites_for_remapping           1
tszip                                  4
map_parsimony                          1
apply_parsimony_heuristics             1
shift_breakpoints                      1
sc2ts_usher_intersection               1
write_fasta                            1
all_sites_parsimony                    2
date_samples                           1
run_pangolin                           1
add_pangolin_metadata                  1
date_internal_nodes                    1
usher_sc2ts_comparison                 1
date                                   1
minimise_metadata_pango_scorpio        1
final_arg_report                       1
total                                 35


[Tue Jun  2 21:12:45 2026]
rule generate_all_sites:
    output: all_sites.txt
    jobid: 33
    reason: Missing output files: all_sites.txt
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule download_pb:
    output: tree.all_viridian.202409.pb.gz
    jobid: 23
    reason: Missing output files: tree.all_viridian.202409.pb.gz
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule initialise:
    input: ../inference/results/v2_2026-04-17/v2_2026-04-17_2024-01-01.ts
    output: sc2ts_v2_2024-01-01.trees
    jobid: 10
    reason: Missing output files: sc2ts_v2_2024-01-01.trees
    wildcards: DATE=2024-01-01
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule deletion_site_data:
    output: Li_et_al_TableS1.xlsx
    jobid: 13
    reason: Missing output files: Li_et_al_TableS1.xlsx
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule download_json:
    output: tree.all_viridian.202409.jsonl.gz
    jobid: 21
    reason: Missing output files: tree.all_viridian.202409.jsonl.gz
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule lineage_mutations:
    output: lineage_mutations.json
    jobid: 14
    reason: Missing output files: lineage_mutations.json
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule rematch_recombinants_lbs:
    input: sc2ts_v2_2024-01-01.trees
    output: sc2ts_v2_2024-01-01_recombinants_lbs.json
    jobid: 11
    reason: Missing output files: sc2ts_v2_2024-01-01_recombinants_lbs.json; Input files updated by another job: sc2ts_v2_2024-01-01.trees
    wildcards: RRL_PREFIX=sc2ts_v2_2024-01-01
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule convert_topology:
    input: tree.all_viridian.202409.jsonl.gz
    output: usher_topology.trees
    jobid: 20
    reason: Missing output files: usher_topology.trees; Input files updated by another job: tree.all_viridian.202409.jsonl.gz
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule export_mutations_local:
    input: tree.all_viridian.202409.pb.gz
    output: usher_mutations.tsv
    jobid: 22
    reason: Missing output files: usher_mutations.tsv; Input files updated by another job: tree.all_viridian.202409.pb.gz
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule add_mutations:
    input: usher_topology.trees, usher_mutations.tsv
    output: usher_v1.trees
    jobid: 19
    reason: Missing output files: usher_v1.trees; Input files updated by another job: usher_topology.trees, usher_mutations.tsv
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule rewire_recombinants:
    input: sc2ts_v2_2024-01-01.trees, sc2ts_v2_2024-01-01_recombinants_lbs.json
    output: sc2ts_v2_2024-01-01_pr.trees
    jobid: 9
    reason: Missing output files: sc2ts_v2_2024-01-01_pr.trees; Input files updated by another job: sc2ts_v2_2024-01-01.trees, sc2ts_v2_2024-01-01_recombinants_lbs.json
    wildcards: PR_PREFIX=sc2ts_v2_2024-01-01
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule minimise_metadata:
    input: usher_v1.trees
    output: usher_v1_mm.trees
    jobid: 18
    reason: Missing output files: usher_v1_mm.trees; Input files updated by another job: usher_v1.trees
    wildcards: MM_PREFIX=usher_v1
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule postprocess:
    input: sc2ts_v2_2024-01-01_pr.trees
    output: sc2ts_v2_2024-01-01_pr_pp.trees
    jobid: 8
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp.trees; Input files updated by another job: sc2ts_v2_2024-01-01_pr.trees
    wildcards: PP_PREFIX=sc2ts_v2_2024-01-01_pr
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule minimise_metadata_date:
    input: usher_v1.trees
    output: usher_v1_mmd.trees
    jobid: 26
    reason: Missing output files: usher_v1_mmd.trees; Input files updated by another job: usher_v1.trees
    wildcards: MM_PREFIX=usher_v1
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule tszip:
    input: usher_v1_mm.trees
    output: usher_v1_mm.trees.tsz
    jobid: 17
    reason: Missing output files: usher_v1_mm.trees.tsz; Input files updated by another job: usher_v1_mm.trees
    wildcards: TSZIP_PREFIX=usher_v1_mm
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule generate_sites_for_remapping:
    input: sc2ts_v2_2024-01-01_pr_pp.trees, Li_et_al_TableS1.xlsx, lineage_mutations.json
    output: sc2ts_v2_2024-01-01_pr_pp_sites_to_remap.csv, sc2ts_v2_2024-01-01_pr_pp_sites_to_remap.txt
    jobid: 12
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_sites_to_remap.txt; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp.trees, Li_et_al_TableS1.xlsx, lineage_mutations.json
    wildcards: GSR_PREFIX=sc2ts_v2_2024-01-01_pr_pp
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule map_parsimony:
    input: ../data/viridian_mafft_2024-10-14_v1.vcz.zip, sc2ts_v2_2024-01-01_pr_pp.trees, sc2ts_v2_2024-01-01_pr_pp_sites_to_remap.txt
    output: sc2ts_v2_2024-01-01_pr_pp_mp.trees, sc2ts_v2_2024-01-01_pr_pp_mp.csv
    jobid: 7
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp.trees; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp.trees, sc2ts_v2_2024-01-01_pr_pp_sites_to_remap.txt
    wildcards: MP_PREFIX=sc2ts_v2_2024-01-01_pr_pp
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule apply_parsimony_heuristics:
    input: sc2ts_v2_2024-01-01_pr_pp_mp.trees
    output: sc2ts_v2_2024-01-01_pr_pp_mp_aph.trees, sc2ts_v2_2024-01-01_pr_pp_mp_aph.csv
    jobid: 6
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp_aph.trees; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp_mp.trees
    wildcards: APH_PREFIX=sc2ts_v2_2024-01-01_pr_pp_mp
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule minimise_metadata:
    input: sc2ts_v2_2024-01-01_pr_pp_mp_aph.trees
    output: sc2ts_v2_2024-01-01_pr_pp_mp_aph_mm.trees
    jobid: 27
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp_aph_mm.trees; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp_mp_aph.trees
    wildcards: MM_PREFIX=sc2ts_v2_2024-01-01_pr_pp_mp_aph
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule shift_breakpoints:
    input: sc2ts_v2_2024-01-01_pr_pp_mp_aph.trees
    output: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.trees
    log: sc2ts_v2_2024-01-01_pr_pp_mp_aph_shift_breakpoints.log
    jobid: 5
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.trees; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp_mp_aph.trees
    wildcards: BP_PREFIX=sc2ts_v2_2024-01-01_pr_pp_mp_aph
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule sc2ts_usher_intersection:
    input: usher_v1_mmd.trees, sc2ts_v2_2024-01-01_pr_pp_mp_aph_mm.trees
    output: usher_2024-01-01_intersection.trees, sc2ts_2024-01-01_intersection.trees
    jobid: 25
    reason: Missing output files: sc2ts_2024-01-01_intersection.trees, usher_2024-01-01_intersection.trees; Input files updated by another job: usher_v1_mmd.trees, sc2ts_v2_2024-01-01_pr_pp_mp_aph_mm.trees
    wildcards: DATE=2024-01-01
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule write_fasta:
    input: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.trees
    output: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.fasta
    jobid: 16
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.fasta; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.trees
    wildcards: WF_PREFIX=sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule date_samples:
    input: usher_2024-01-01_intersection.trees
    output: usher_2024-01-01_intersection_ds.trees
    jobid: 30
    reason: Missing output files: usher_2024-01-01_intersection_ds.trees; Input files updated by another job: usher_2024-01-01_intersection.trees
    wildcards: DS_PREFIX=usher_2024-01-01_intersection
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule tszip:
    input: sc2ts_2024-01-01_intersection.trees
    output: sc2ts_2024-01-01_intersection.trees.tsz
    jobid: 24
    reason: Missing output files: sc2ts_2024-01-01_intersection.trees.tsz; Input files updated by another job: sc2ts_2024-01-01_intersection.trees
    wildcards: TSZIP_PREFIX=sc2ts_2024-01-01_intersection
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule all_sites_parsimony:
    input: ../data/viridian_mafft_2024-10-14_v1.vcz.zip, sc2ts_2024-01-01_intersection.trees, all_sites.txt
    output: sc2ts_2024-01-01_intersection_asp.trees, sc2ts_2024-01-01_intersection_asp.csv
    jobid: 34
    reason: Missing output files: sc2ts_2024-01-01_intersection_asp.trees, sc2ts_2024-01-01_intersection_asp.csv; Input files updated by another job: sc2ts_2024-01-01_intersection.trees, all_sites.txt
    wildcards: ASP_PREFIX=sc2ts_2024-01-01_intersection
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule run_pangolin:
    input: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.fasta
    output: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.lineage_report.csv
    jobid: 15
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.lineage_report.csv; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.fasta
    wildcards: RP_PREFIX=sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule all_sites_parsimony:
    input: ../data/viridian_mafft_2024-10-14_v1.vcz.zip, usher_2024-01-01_intersection.trees, all_sites.txt
    output: usher_2024-01-01_intersection_asp.trees, usher_2024-01-01_intersection_asp.csv
    jobid: 32
    reason: Missing output files: usher_2024-01-01_intersection_asp.trees, usher_2024-01-01_intersection_asp.csv; Input files updated by another job: all_sites.txt, usher_2024-01-01_intersection.trees
    wildcards: ASP_PREFIX=usher_2024-01-01_intersection
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule date_internal_nodes:
    input: usher_2024-01-01_intersection_ds.trees
    output: usher_2024-01-01_intersection_ds_di.trees
    jobid: 29
    reason: Missing output files: usher_2024-01-01_intersection_ds_di.trees; Input files updated by another job: usher_2024-01-01_intersection_ds.trees
    wildcards: DI_PREFIX=usher_2024-01-01_intersection_ds
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule add_pangolin_metadata:
    input: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.trees, sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.lineage_report.csv
    output: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango.trees
    jobid: 4
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango.trees; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.lineage_report.csv, sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps.trees
    wildcards: APM_PREFIX=sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule usher_sc2ts_comparison:
    input: usher_2024-01-01_intersection.trees, usher_2024-01-01_intersection_asp.trees, usher_2024-01-01_intersection_asp.csv, sc2ts_2024-01-01_intersection.trees, sc2ts_2024-01-01_intersection_asp.trees, sc2ts_2024-01-01_intersection_asp.csv
    log: logs/usher_sc2ts_comparison_2024-01-01.ipynb
    jobid: 31
    reason: Rules with a run or shell declaration but no output are always executed.
    wildcards: DATE=2024-01-01
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule tszip:
    input: usher_2024-01-01_intersection_ds_di.trees
    output: usher_2024-01-01_intersection_ds_di.trees.tsz
    jobid: 28
    reason: Missing output files: usher_2024-01-01_intersection_ds_di.trees.tsz; Input files updated by another job: usher_2024-01-01_intersection_ds_di.trees
    wildcards: TSZIP_PREFIX=usher_2024-01-01_intersection_ds_di
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule date:
    input: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango.trees
    output: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated.trees
    jobid: 3
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated.trees; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango.trees
    wildcards: DATE_PREFIX=sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule minimise_metadata_pango_scorpio:
    input: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated.trees
    output: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated_mmps.trees
    jobid: 2
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated_mmps.trees; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated.trees
    wildcards: MM_PREFIX=sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule tszip:
    input: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated_mmps.trees
    output: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated_mmps.trees.tsz
    jobid: 1
    reason: Missing output files: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated_mmps.trees.tsz; Input files updated by another job: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated_mmps.trees
    wildcards: TSZIP_PREFIX=sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated_mmps
    resources: tmpdir=/tmp
[Tue Jun  2 21:12:45 2026]
rule final_arg_report:
    input: sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated_mmps.trees.tsz, usher_v1_mm.trees.tsz, sc2ts_2024-01-01_intersection.trees.tsz, usher_2024-01-01_intersection_ds_di.trees.tsz
    output: sc2ts_viridian_2024-01-01.trees.tsz, usher_viridian_2024-01-01.trees.tsz, sc2ts_viridian_inter_2024-01-01.trees.tsz, usher_viridian_inter_2024-01-01.trees.tsz
    log: logs/final_arg_report_2024-01-01.ipynb
    jobid: 0
    reason: Missing output files: logs/final_arg_report_2024-01-01.ipynb; Input files updated by another job: usher_2024-01-01_intersection_ds_di.trees.tsz, sc2ts_v2_2024-01-01_pr_pp_mp_aph_bps_pango_dated_mmps.trees.tsz, sc2ts_2024-01-01_intersection.trees.tsz, usher_v1_mm.trees.tsz
    wildcards: DATE=2024-01-01
    resources: tmpdir=/tmp
Job stats:
job                                count
-------------------------------  -------
deletion_site_data                     1
download_json                          1
download_pb                            1
generate_all_sites                     1
initialise                             1
lineage_mutations                      1
convert_topology                       1
export_mutations_local                 1
rematch_recombinants_lbs               1
add_mutations                          1
rewire_recombinants                    1
minimise_metadata                      2
minimise_metadata_date                 1
postprocess                            1
generate_sites_for_remapping           1
tszip                                  4
map_parsimony                          1
apply_parsimony_heuristics             1
shift_breakpoints                      1
sc2ts_usher_intersection               1
write_fasta                            1
all_sites_parsimony                    2
date_samples                           1
run_pangolin                           1
add_pangolin_metadata                  1
date_internal_nodes                    1
usher_sc2ts_comparison                 1
date                                   1
minimise_metadata_pango_scorpio        1
final_arg_report                       1
total                                 35

Reasons:
    (check individual jobs above for details)
    input files updated by another job:
        add_mutations, add_pangolin_metadata, all_sites_parsimony, apply_parsimony_heuristics, convert_topology, date, date_internal_nodes, date_samples, export_mutations_local, final_arg_report, generate_sites_for_remapping, map_parsimony, minimise_metadata, minimise_metadata_date, minimise_metadata_pango_scorpio, postprocess, rematch_recombinants_lbs, rewire_recombinants, run_pangolin, sc2ts_usher_intersection, shift_breakpoints, tszip, usher_sc2ts_comparison, write_fasta
    output files have to be generated:
        add_mutations, add_pangolin_metadata, all_sites_parsimony, apply_parsimony_heuristics, convert_topology, date, date_internal_nodes, date_samples, deletion_site_data, download_json, download_pb, export_mutations_local, final_arg_report, generate_all_sites, generate_sites_for_remapping, initialise, lineage_mutations, map_parsimony, minimise_metadata, minimise_metadata_date, minimise_metadata_pango_scorpio, postprocess, rematch_recombinants_lbs, rewire_recombinants, run_pangolin, sc2ts_usher_intersection, shift_breakpoints, tszip, write_fasta
    run or shell but no output:
        usher_sc2ts_comparison
This was a dry-run (flag -n). The order of jobs does not reflect the order of execution.
```