### PR TITLE
Debug rewiring

### DIFF
--- a/arg_postprocessing/notebooks/rewire-recombinants-report.py.ipynb
+++ b/arg_postprocessing/notebooks/rewire-recombinants-report.py.ipynb
@@ -54,6 +54,10 @@
     "        hmm_match = lbs.hmm_match\n",
     "\n",
     "    if hmm_match is not None:\n",
+    "        assert len(r.original_match.path) == 2\n",
+    "        bp = r.original_match.path[0].right\n",
+    "        tree_in.seek(bp)\n",
+    "        tree_out.seek(bp)\n",
     "        old_descendants = tree_in.num_samples(r.recombinant)\n",
     "        new_descendants = tree_out.num_samples(r.recombinant)\n",
     "        assert old_descendants == new_descendants\n",
@@ -293,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "ipykernel",
     "ipython",
     "ipywidgets",
+    "numba",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "Convenience environment for running (most of) the sc2ts-paper notebooks."
 requires-python = ">=3.11"
 dependencies = [
-    "sc2ts",
+    "sc2ts[inference]",
     "zarr<3",
     "tskit",
     "tszip",
@@ -26,7 +26,6 @@ dependencies = [
     "ipykernel",
     "ipython",
     "ipywidgets",
-    "numba",
 ]
 
 [tool.uv]


### PR DESCRIPTION
It's not obvious to me how this happens, but for two of the recombinants there was a small difference in the number of descendants on the left-most tree (about 5 samples each). If we look at the tree at the breakpoint though, they match up. It seems likely that small rearrangements in the subtrees below these recombinants could result in this (and they were both big - one was the largest 500K sample outlier).